### PR TITLE
[UPDATE] #BTS-39 : 소설상세페이지 변경

### DIFF
--- a/components/pages/noveldetail/CommentList.module.css
+++ b/components/pages/noveldetail/CommentList.module.css
@@ -1,5 +1,7 @@
 .CommentCard {
-  margin: 1rem 2rem;
+  margin: 1rem 0rem;
+  width: 100%;
+  height: 6rem;
 }
 .commentListInfo {
   display: flex;
@@ -31,8 +33,9 @@
 }
 .episodeIcons {
   display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 .episodeIcons img {
-  margin-top: 0.7rem;
   margin-right: 0.7rem;
 }

--- a/components/pages/noveldetail/CommentList.tsx
+++ b/components/pages/noveldetail/CommentList.tsx
@@ -2,104 +2,169 @@ import React from "react";
 import style from "@/components/pages/noveldetail/CommentList.module.css";
 import NewUi from "@/components/ui/NewUi";
 import Image from "next/image";
+import LineSeparator from "@/components/ui/LineSeparator";
 export default function CommentList() {
   return (
     <>
-      <div className={style.CommentCard}>
-        <div className={style.commentListInfo}>
-          <div className={style.commentListTitle}>
-            <div className={style.commentWriter}>밍개미</div>
-            <NewUi />
+      <div className={style.CommentContainer}>
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미</div>
+              <NewUi />
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
           </div>
-          <div className={style.commentDay}>2023.04.25</div>
-        </div>
-        <div className={style.comment}>
-          무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
-        </div>
-        <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
-      </div>
-
-      <div className={style.CommentCard}>
-        <div className={style.commentListInfo}>
-          <div className={style.commentListTitle}>
-            <div className={style.commentMyWrite}>Juliet(작성자)</div>
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
           </div>
-          <div className={style.commentDay}>2023.04.25</div>
-        </div>
-        <div className={style.comment}>
-          무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
-        </div>
-        <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
-        <div className={style.episodeIcons}>
-          <Image
-            src="/assets/images/icons/write.svg"
-            alt="left-arrow"
-            width={20}
-            height={20}
-            priority
-          />
-          <Image
-            src="/assets/images/icons/trash-2.svg"
-            alt="left-arrow"
-            width={20}
-            height={20}
-            priority
-          />
-        </div>
-      </div>
-
-      <div className={style.CommentCard}>
-        <div className={style.commentListInfo}>
-          <div className={style.commentListTitle}>
-            <div className={style.commentWriter}>밍개미</div>
-            <NewUi />
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
           </div>
-          <div className={style.commentDay}>2023.04.25</div>
         </div>
-        <div className={style.comment}>
-          무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
-        </div>
-        <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
-      </div>
-
-      <div className={style.CommentCard}>
-        <div className={style.commentListInfo}>
-          <div className={style.commentListTitle}>
-            <div className={style.commentWriter}>밍개미</div>
-            <NewUi />
+        <LineSeparator colorline="grayline" />
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미(작성자)</div>
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
           </div>
-          <div className={style.commentDay}>2023.04.25</div>
-        </div>
-        <div className={style.comment}>
-          무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
-        </div>
-        <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
-      </div>
-      <div className={style.CommentCard}>
-        <div className={style.commentListInfo}>
-          <div className={style.commentListTitle}>
-            <div className={style.commentWriter}>밍개미</div>
-            <NewUi />
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
           </div>
-          <div className={style.commentDay}>2023.04.25</div>
-        </div>
-        <div className={style.comment}>
-          무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
-        </div>
-        <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
-      </div>
-      <div className={style.CommentCard}>
-        <div className={style.commentListInfo}>
-          <div className={style.commentListTitle}>
-            <div className={style.commentWriter}>밍개미</div>
-            <NewUi />
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+            <div>
+              <Image
+                src="/assets/images/icons/write.svg"
+                alt="left-arrow"
+                width={20}
+                height={20}
+                priority
+              />
+              <Image
+                src="/assets/images/icons/trash-2.svg"
+                alt="left-arrow"
+                width={20}
+                height={20}
+                priority
+              />
+            </div>
           </div>
-          <div className={style.commentDay}>2023.04.25</div>
         </div>
-        <div className={style.comment}>
-          무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
+        <LineSeparator colorline="grayline" />
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미</div>
+              <NewUi />
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
+          </div>
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
+          </div>
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+          </div>
         </div>
-        <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+        <LineSeparator colorline="grayline" />
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미</div>
+              <NewUi />
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
+          </div>
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
+          </div>
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+          </div>
+        </div>
+        <LineSeparator colorline="grayline" />
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미</div>
+              <NewUi />
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
+          </div>
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
+          </div>
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+          </div>
+        </div>
+        <LineSeparator colorline="grayline" />
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미</div>
+              <NewUi />
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
+          </div>
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
+          </div>
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+          </div>
+        </div>
+        <LineSeparator colorline="grayline" />
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미</div>
+              <NewUi />
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
+          </div>
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
+          </div>
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+          </div>
+        </div>
+        <LineSeparator colorline="grayline" />
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미</div>
+              <NewUi />
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
+          </div>
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
+          </div>
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+          </div>
+        </div>
+        <LineSeparator colorline="grayline" />
+        <div className={style.CommentCard}>
+          <div className={style.commentListInfo}>
+            <div className={style.commentListTitle}>
+              <div className={style.commentWriter}>밍개미</div>
+              <NewUi />
+            </div>
+            <div className={style.commentDay}>2023.04.25</div>
+          </div>
+          <div className={style.comment}>
+            무협 좀비아포칼립스는 ㄹㅇ 빡센데 ㄷㄷ 화전민촌들이 다 휩쓸리겟네
+          </div>
+          <div className={style.episodeIcons}>
+            <div className={style.episodeTitle}>신과함께 레벨업 080화</div>
+          </div>
+        </div>
       </div>
     </>
   );

--- a/components/pages/noveldetail/CommentsCheck.module.css
+++ b/components/pages/noveldetail/CommentsCheck.module.css
@@ -1,8 +1,8 @@
-.container{
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin: 0rem 2rem;
-    color: var(--readme-title-gray);
-    font-weight: 600;
+.container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--readme-title-gray);
+  font-weight: 600;
+  font-size: 0.875rem;
 }

--- a/components/pages/noveldetail/CommentsCheck.tsx
+++ b/components/pages/noveldetail/CommentsCheck.tsx
@@ -5,12 +5,7 @@ export default function CommentsCheck() {
   return (
     <div className={style.container}>
       <div>댓글 320</div>
-      <LineSeparator
-        backgroundcolor={"#7fffa3"}
-        width="65%"
-        height="2px"
-        margin="1rem 0rem"
-      />
+      <LineSeparator colorline="greenline" />
     </div>
   );
 }

--- a/components/pages/noveldetail/EpisodeInfo.module.css
+++ b/components/pages/noveldetail/EpisodeInfo.module.css
@@ -10,15 +10,15 @@
   justify-content: space-between;
   align-items: center;
 }
-.sortIcon {
+.sortTitle {
   display: flex;
   align-items: center;
   color: var(--readme-title-gray);
   font-weight: 800;
-  font-size: 0.875;
+  font-size: 0.875rem;
 }
-.sortIcon img {
-  margin: 0.4rem;
+.sortTitle div {
+  margin-left: 0.4rem;
 }
 .episodeCard {
   display: flex;
@@ -33,20 +33,29 @@
 .episodeFreeNew img {
   margin-right: 0.4rem;
 }
+.episodeCardTitleNew {
+  display: flex;
+  align-items: center;
+}
 .episodeTitle {
   font-size: 1rem;
   color: var(--readme-title-gray);
-  margin: 0.2rem 0rem;
+  margin: 0.2rem 0.5rem 0.2rem 0rem;
   font-weight: 800;
 }
-.episodeCardInfo{
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-.episodeDay {
+.episodeDayFree {
   font-size: 0.76rem;
   font-weight: 800;
   color: var(--readme-title-gray);
-  margin: 0.1rem 0rem 0.7rem 0rem;
+  display: flex;
+  align-items: center;
+  margin: 0.5rem 0rem;
+}
+.episodeCardInfo {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.episodeDay {
+  margin-right: 0.5rem;
 }

--- a/components/pages/noveldetail/EpisodeInfo.tsx
+++ b/components/pages/noveldetail/EpisodeInfo.tsx
@@ -1,92 +1,256 @@
-import React from "react";
+import React, { Children } from "react";
 import style from "@/components/pages/noveldetail/EpisodeInfo.module.css";
-import Image from "next/image";
 import LineSeparator from "@/components/ui/LineSeparator";
 import NewUi from "@/components/ui/NewUi";
-import CheckCircleUi from "@/components/ui/CheckCircleUi";
+
 export default function EpisodeInfo() {
   return (
     <div className={style.container}>
       <div className={style.sortNovel}>
-        <LineSeparator
-          backgroundcolor={"#7fffa3"}
-          width="65%"
-          height="2px"
-          margin="1rem 0rem"
-        />
-        <div className={style.sortIcon}>
-          <Image
-            src={"/assets/images/icons/upload.svg"}
-            alt="썸네일 이미지"
-            width={20}
-            height={20}
-          />
-          <div>첫화부터</div>
+        <LineSeparator colorline="greenline" />
+        <div className={style.sortTitle}>
+          <div>최신순</div>
+          <div>1화부터</div>
         </div>
       </div>
-      <div className={style.episodeCard}>
-        <div className={style.episodeFreeNew}>
-          <Image
-            src={"/assets/images/icons/freeicon.svg"}
-            alt="썸네일 이미지"
-            width={50}
-            height={25}
-          />
-          <NewUi />
-        </div>
 
-        <div className={style.episodeCardInfo}>
-          <div className={style.episodeCardDescription}>
-            <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
-            <div className={style.episodeDay}>2023.05.23</div>
-          </div>
-        </div>
-      </div>
-      <LineSeparator
-        backgroundcolor="var(--readme-gray-dark)"
-        width="100%"
-        height="1px"
-        margin="0.2rem 0"
-      />
-      <div className={style.episodeCard}>
-        <div className={style.episodeFreeNew}>
-          <Image
-            src={"/assets/images/icons/freeicon.svg"}
-            alt="썸네일 이미지"
-            width={50}
-            height={25}
-          />
-          <NewUi />
-        </div>
-        <div className={style.episodeCardInfo}>
-          <div className={style.episodeCardDescription}>
-            <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
-            <div className={style.episodeDay}>2023.05.23</div>
-          </div>
-          <CheckCircleUi />
-        </div>
-      </div>
-      <LineSeparator
-        backgroundcolor="var(--readme-gray-dark)"
-        width="100%"
-        height="1px"
-        margin="0.2rem 0"
-      />
       <div className={style.episodeCard}>
         <div className={style.episodeCardInfo}>
           <div className={style.episodeCardDescription}>
-            <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
-            <div className={style.episodeDay}>2023.05.23</div>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+              <NewUi />
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+              <div>무료</div>
+            </div>
           </div>
-          <CheckCircleUi />
         </div>
       </div>
-      <LineSeparator
-        backgroundcolor="var(--readme-gray-dark)"
-        width="100%"
-        height="1px"
-        margin="0.2rem 0"
-      />
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <LineSeparator colorline="grayline" />
+      <div className={style.episodeCard}>
+        <div className={style.episodeCardInfo}>
+          <div className={style.episodeCardDescription}>
+            <div className={style.episodeCardTitleNew}>
+              <div className={style.episodeTitle}>신과 함께 레벨업 635화</div>
+              <NewUi />
+            </div>
+            <div className={style.episodeDayFree}>
+              <div className={style.episodeDay}>2023.05.23</div>
+              <div>무료</div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/pages/noveldetail/NovelDetailHeader.module.css
+++ b/components/pages/noveldetail/NovelDetailHeader.module.css
@@ -31,12 +31,12 @@
   width: 80%;
   text-align: center;
 }
-.noevelMainTitle{
+.noevelMainTitle {
   font-size: 1.125rem;
   font-weight: 800;
   color: var(--readme-primary);
 }
-.novelDetailTitle p{
-margin: 0.5rem;
-font-size: 0.75rem;
+.novelDetailTitle p {
+  margin: 0.5rem;
+  font-size: 0.75rem;
 }

--- a/components/pages/noveldetail/NovelDetailMenu.module.css
+++ b/components/pages/noveldetail/NovelDetailMenu.module.css
@@ -1,20 +1,25 @@
-.menutitle{
-    margin: 1rem 2rem;
-    display: flex;
-    justify-content: space-between;
+.menutitle {
+  margin: 1rem 2rem;
+  display: flex;
+  justify-content: space-between;
 }
-.menutitle p{
-    font-size: 0.875rem;
-    font-weight: 600;
+.menutitle p {
+  font-size: 0.875rem;
+  font-weight: 600;
 }
-.infoCentainer{
-    display: flex;
-    margin:0rem 0rem 8rem 0rem;
-    flex-direction: column;
+.infoCentainer {
+  display: flex;
+  margin: 0rem 2rem 7rem 2rem;
+  flex-direction: column;
 }
-.menuactive{
-    padding-bottom: 0.4rem;
-    color: var(--readme-primary);
-    font-weight: 800;
-    border-bottom: 2px solid var(--readme-primary);
+.menuactive {
+  padding-bottom: 0.4rem;
+  color: var(--readme-primary);
+  font-weight: 800;
+  border-bottom: 2px solid var(--readme-primary);
+}
+.detailTitle {
+  font-size: 0.875rem;
+  font-weight: 550;
+  margin: 0.5rem 0rem;
 }

--- a/components/pages/noveldetail/NovelDetailMenu.tsx
+++ b/components/pages/noveldetail/NovelDetailMenu.tsx
@@ -1,10 +1,7 @@
 import React, { useState } from "react";
 import style from "@/components/pages/noveldetail/NovelDetailMenu.module.css";
-import TagUi from "@/components/ui/TagUi";
 import NovelIntroduce from "./NovelIntroduce";
 import EpisodeInfo from "./EpisodeInfo";
-import { tagType } from "@/types/model/detailPageDataTypes";
-import DetailTitle from "@/components/ui/DetailTitle";
 import LineSeparator from "@/components/ui/LineSeparator";
 import CommentsCheck from "./CommentsCheck";
 import CommentList from "./CommentList";
@@ -46,25 +43,10 @@ export default function NovelDetailMenu() {
       {currentTab === 0 && (
         <>
           <div className={style.infoCentainer}>
-            <DetailTitle
-              title={"시놉시스"}
-              size={"0.875rem"}
-              leftsize={"2rem"}
-              fontweight={550}
-            />
+            <div className={style.detailTitle}>시놉시스</div>
             <NovelIntroduce />
-            <LineSeparator
-              backgroundcolor={"#99ffb5"}
-              width="80%"
-              height="1px"
-              margin="1rem 2rem"
-            />
-            <DetailTitle
-              title={"작가의 한마디"}
-              size={"0.875rem"}
-              leftsize={"2rem"}
-              fontweight={550}
-            />
+            <LineSeparator colorline="grayline" />
+            <div className={style.detailTitle}>작가의 한마디</div>
             <NovelIntroduce />
           </div>
         </>

--- a/components/pages/noveldetail/NovelDetailinfo.module.css
+++ b/components/pages/noveldetail/NovelDetailinfo.module.css
@@ -4,30 +4,30 @@
   justify-content: center;
   align-items: center;
   flex-direction: column;
-  margin-top:5rem;
+  margin-top: 5rem;
   position: relative;
 }
-.novelMainImageInfo{
-    border-radius: 10px;
-    width: 100%;
-    height: 560px;
+.novelMainImageInfo {
+  border-radius: 10px;
+  width: 100%;
+  height: 560px;
 }
-.novelMainImageInfo img{
-    width: 100%;
-    height: 500px;
-    border-radius: 20px;
+.novelMainImageInfo img {
+  width: 100%;
+  height: 500px;
+  border-radius: 20px;
 }
-.detailnovellikes{
-    height:4rem;
-    width: 90%;
-    margin: 1rem;
-    background-color: white;
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-    border-radius: 1rem;
-    border: 1px solid var(--readme-secondary);
-    box-shadow: 2px 4px 5px 0px var(--readme-secondary);
-position: absolute;
-bottom: 10px;
+.detailnovellikes {
+  height: 4rem;
+  width: 90%;
+  margin: 1rem;
+  background-color: white;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  border-radius: 1rem;
+  border: 1px solid var(--readme-secondary);
+  box-shadow: 2px 4px 5px 0px var(--readme-secondary);
+  position: absolute;
+  bottom: 10px;
 }

--- a/components/pages/noveldetail/NovelIntroduce.module.css
+++ b/components/pages/noveldetail/NovelIntroduce.module.css
@@ -1,4 +1,4 @@
-.authorinfo{
-    margin: 1rem 2rem;
-    font-size: 0.75rem;
+.authorinfo {
+  font-size: 0.75rem;
+  margin: 0.5rem 0rem;
 }

--- a/components/pages/noveldetail/NovelTages.module.css
+++ b/components/pages/noveldetail/NovelTages.module.css
@@ -1,6 +1,6 @@
-.novelTagContainer{
-    display: flex;
-    justify-content: center;
-    flex-wrap: wrap;
-    padding: 1rem 3rem;
+.novelTagContainer {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  padding: 0.5rem 3rem;
 }

--- a/components/pages/noveldetail/NovelTages.tsx
+++ b/components/pages/noveldetail/NovelTages.tsx
@@ -1,13 +1,12 @@
-import React from 'react'
-import TagUi from '@/components/ui/TagUi'
+import React from "react";
+import TagUi from "@/components/ui/TagUi";
 import style from "@/components/pages/noveldetail/NovelTages.module.css";
 export default function NovelTages() {
   return (
     <div className={style.novelTagContainer}>
-      <TagUi title="웹소설"/>
-      <TagUi title="완결"/>
-      <TagUi title="흑아인"/>
-      <TagUi title="급상승어"/>
+      <TagUi title="웹소설판타지" />
+      <TagUi title="완결" />
+      <TagUi title="흑아인" />
     </div>
-  )
+  );
 }

--- a/components/ui/LineSeparator.module.css
+++ b/components/ui/LineSeparator.module.css
@@ -1,0 +1,12 @@
+.grayline {
+  background-color: var(--readme-gray-dark);
+  width: 100%;
+  height: 1px;
+  margin: 0.5rem 0rem;
+}
+.greenline {
+  background-color: var(--readme-secondary);
+  width: 65%;
+  height: 1px;
+  margin: 1rem 0rem;
+}

--- a/components/ui/LineSeparator.tsx
+++ b/components/ui/LineSeparator.tsx
@@ -1,18 +1,17 @@
 import React from "react";
-export default function LineSeparator(props: {
-  backgroundcolor: string;
-  width: string;
-  height: string;
-  margin: string;
-}) {
+import style from "@/components/ui/LineSeparator.module.css";
+interface Props {
+  colorline: "grayline" | "greenline";
+  children?: any;
+}
+const LineSeparator = ({ colorline, children }: Props) => {
   return (
     <div
-      style={{
-        backgroundColor: props.backgroundcolor,
-        width: props.width,
-        height: props.height,
-        margin: props.margin,
-      }}
-    ></div>
+      className={colorline === "grayline" ? style.grayline : style.greenline}
+    >
+      {children}
+    </div>
   );
-}
+};
+
+export default LineSeparator;

--- a/components/ui/TagUi.module.css
+++ b/components/ui/TagUi.module.css
@@ -1,20 +1,22 @@
-.tags{
-    display: flex;
-    justify-content: start;
-    flex-direction: row;
-    margin: 0.2rem;
-    width: fit-content;
-
+.tags {
+  display: flex;
+  justify-content: start;
+  flex-direction: row;
+  margin: 0.1rem;
+  width: 5rem;
 }
-.tagtitle{
-    width: fit-content;
-    height: auto;
-    background-color: var(--readme-gray-light);
-    border-radius: 2rem;
-    color:var(--readme-black);
-    /* margin:0.3rem 0.1rem; */
-    font-size: 0.7rem;
+.tagtitle {
+  width: 100%;
+  height: auto;
+  background-color: var(--readme-gray-light);
+  border-radius: 2rem;
+  color: var(--readme-black);
+  font-size: 0.7rem;
 }
 .tagtitle p {
-    padding: 0.5rem 0.7rem;
+  padding: 0.4rem 0.7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
 }

--- a/components/ui/TagUi.tsx
+++ b/components/ui/TagUi.tsx
@@ -1,9 +1,11 @@
-import React from 'react'
-import style from '@/components/ui/TagUi.module.css'
-export default function TagUi(props:{title:string}) {
+import React from "react";
+import style from "@/components/ui/TagUi.module.css";
+export default function TagUi(props: { title: string }) {
   return (
     <div className={style.tags}>
-      <div className={style.tagtitle}><p>{props.title}</p></div>
+      <div className={style.tagtitle}>
+        <p>{props.title}</p>
+      </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
- 태그 컴포넌트(넓이고정) : 전반적인 UI를 생각했을 때 한줄로 처리하는 것 갯수를 제한하는 것(3개)으로 협의
- 구분선 컴포넌트(회색, 형광색) 구분
- Title 컴포넌트 삭제 -> 추후 필요시 컴포넌트화 할 예정
- 에피소트 탭의 경우 무료인 소설, New소설로 구분이 되는데 높이에 영향을 미치지않게 똑같은 높이로 구현 -> 추후 컴포넌트화 진행예정
- 댓글 탭도 마찬가지로 작성자와 작성자가 아닌경우로 구분이 되는데 높이에 영향을 미치지않게 똑같은 높이로 구현 -> 추후 컴포넌트화 진행예정