### PR TITLE
[UPDATE] #BTS-135 : 뷰어페이지

### DIFF
--- a/components/pages/viewer/NovelViewer.tsx
+++ b/components/pages/viewer/NovelViewer.tsx
@@ -40,8 +40,8 @@ export default function NovelViewer(props: { viewerData: string }) {
     setIsEmojiPanelVisible(true);
 
     if ("touches" in event) {
-      setXNumber(event.touches[0].clientX);
-      setYNumber(event.touches[0].clientY);
+      setXNumber(event.changedTouches[0].clientX);
+      setYNumber(event.changedTouches[0].clientY);
     } else {
       setXNumber(event.clientX);
       setYNumber(event.clientY);
@@ -178,33 +178,33 @@ const ListView = (props: {
 
   return (
     <>
-      <div
-        className={style.emojiContainer}
-        onTouchStart={listHandler}
-        onMouseDown={listHandler}
-      >
-        <span
-          dangerouslySetInnerHTML={{
-            __html: props.data.content
-              .replace(/<p>/g, "")
-              .replace(/<\/p>/g, ""),
-          }}
-        />
-        {emojiList &&
-          emojiList.map(
-            (item: EmojiList) =>
-              item.count > 0 && (
-                <span
-                  key={item.id}
-                  className={style.emojiItem}
-                  onClick={() => handleAddEmoji(item.id)}
-                >
-                  {item.emoji}
-                  {item.count}
-                </span>
-              )
-          )}
-      </div>
-    </>
+    <div
+      className={style.emojiContainer}
+      onTouchStart={listHandler}
+      onMouseUp={listHandler}
+    >
+      <span
+        dangerouslySetInnerHTML={{
+          __html: props.data.content
+            .replace(/<p>/g, "")
+            .replace(/<\/p>/g, ""),
+        }}
+      />
+      {emojiList &&
+        emojiList.map(
+          (item: EmojiList) =>
+            item.count > 0 && (
+              <span
+                key={item.id}
+                className={style.emojiItem}
+                onClick={() => handleAddEmoji(item.id)}
+              >
+                {item.emoji}
+                {item.count}
+              </span>
+            )
+        )}
+    </div>
+  </>
   );
 };

--- a/components/widget/EmojiPannel.tsx
+++ b/components/widget/EmojiPannel.tsx
@@ -43,11 +43,10 @@ export default function EmojiPannel(props: EmojiPannelProps) {
     handleRender();
   }, []);
 
-  useEffect(() => {
-    if (!isEmojiPanelVisible) {
-      onHidePanel();
-    }
-  }, [isEmojiPanelVisible, onHidePanel]);
+  const handleClick = (id: number) => {
+    emojiHandler(id);
+    onHidePanel();
+  };
 
   return (
     <div
@@ -66,10 +65,7 @@ export default function EmojiPannel(props: EmojiPannelProps) {
         <div
           key={item.id}
           className={style.emoji}
-          onClick={() => {
-            emojiHandler(item.id);
-            onHidePanel();
-          }}
+          onClick={() => handleClick(item.id)}
         >
           {item.emoji}
         </div>


### PR DESCRIPTION
onTouchStart는 터치를 시작하는 순간 이모지 패널을 보여줌
onTouchEnd 이벤트가 '터치하고 떼는' 전체 동작을 끝내야만 발생함

=> 전체 동작이 끝난 후에 이벤트가 발생하기 떄문에 onTouchStart로 처리

onMouseDown: 마우스 버튼을 클릭하면서 아직 떼지 않은 상태에서 이 이벤트가 발생
onMouseUp: 마우스 버튼을 눌렀다가 떼는 순간 이 이벤트가 발생

=> 터치가 끝난 후 이벤트가 발생해야하기 때문에 onMouseUp으로 처리