### PR TITLE
[UPDATE] #BTS-163 : 내 서재 CSS 깨짐 수정

### DIFF
--- a/components/pages/library/NovelCardList.module.css
+++ b/components/pages/library/NovelCardList.module.css
@@ -27,7 +27,7 @@
   margin-bottom: 7rem;
 }
 
-.novelContainer p{
+.empty p{
   width: 100%;
   height: 20rem;
   display: flex;

--- a/components/pages/library/NovelCardList.tsx
+++ b/components/pages/library/NovelCardList.tsx
@@ -31,7 +31,9 @@ export default function NovelCardList({ data, totalElements }: Props) {
             <NovelListItem key={index} novelData={item} />
           ))
         ) : (
-          <p>{info}</p>
+          <div className={style.empty}>
+            <p>{info}</p>
+          </div>
         )}
       </div>
     </>


### PR DESCRIPTION
- 영역 설정이 꼬여서 일어나던 css 깨짐현상을 div를 지정해줌으로써 해결함.