### PR TITLE
[UPDATE] #BTS-140 : 결제 과정 수정

### DIFF
--- a/components/pages/mypage/Logout.tsx
+++ b/components/pages/mypage/Logout.tsx
@@ -6,8 +6,11 @@ export default function Logout() {
   const [, , removeCookie] = useCookies(["accessToken", "uuid"]);
   const router = useRouter();
   const logoutHandle = () => {
-    localStorage.removeItem("uuid");
+    //localStorage.removeItem("uuid");
     localStorage.removeItem("name");
+    localStorage.removeItem("nickname");
+    localStorage.removeItem("point");
+    localStorage.removeItem("profileImg");
     localStorage.removeItem("age");
 
     removeCookie("accessToken", { path: "/" });

--- a/components/pages/noveldetail/EpisodeInfo.tsx
+++ b/components/pages/noveldetail/EpisodeInfo.tsx
@@ -15,7 +15,7 @@ export default function EpisodeInfo(props: {
 }) {
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [situation, setSituation] = useState<string>("");
+  const [situation, setSituation] = useState<"결제" | "부족">("부족");
   const [color, setColor] = useState<string>("");
   const [epiId, setEpiId] = useState<number>(0);
   const [cookies] = useCookies(["uuid"]);
@@ -34,29 +34,20 @@ export default function EpisodeInfo(props: {
         const response = await axios.get(
           `/payments-service/v1/payments/checkPurchased?episodeId=${id}`
         );
-
         //구매 x -> 에피소드구매
         if (response.data.data.result === false) {
-          const res = await axios.post(
-            `/payments-service/v1/payments/purchase`,
-            {
-              uuid: cookies.uuid,
-              episodeId: id,
-            }
-          );
-          const data = JSON.parse(res.data.replace("data:", ""));
+          const userPoint = Number(localStorage.getItem("point"));
 
           //포인트 부족
-          if (data.body.data.result === "fail") {
+          if (userPoint < 100) {
             setColor("green");
             setSituation("부족");
             setIsModalOpen(!isModalOpen);
           }
-
           //포인트 보유
           else {
             setColor("purple");
-            setSituation("차감");
+            setSituation("결제");
             setIsModalOpen(!isModalOpen);
           }
         }

--- a/components/pages/point/PointBottom.tsx
+++ b/components/pages/point/PointBottom.tsx
@@ -11,23 +11,16 @@ import { useCookies } from "react-cookie";
 export default function PointBottom() {
   const [cookies] = useCookies(["uuid"]);
   const clickMoney = () => {
-    if (cookies.uuid) {
-      axios
-        .post(`/payments-service/v1/payments/ready`, {
-          point: point,
-          uuid: cookies.uuid,
-        })
-        .then((res) => {
-          localStorage.setItem("tid", res.data.data.tid);
-          localStorage.setItem(
-            "partnerOrderId",
-            res.data.data.partner_order_id
-          );
-          window.open(res.data.data.next_redirect_pc_url);
-        });
-    } else {
-      //로그인이 필요한 서비스라고 알림
-    }
+    axios
+      .post(`/payments-service/v1/payments/ready`, {
+        point: point,
+        uuid: cookies.uuid,
+      })
+      .then((res) => {
+        localStorage.setItem("tid", res.data.data.tid);
+        localStorage.setItem("partnerOrderId", res.data.data.partner_order_id);
+        window.open(res.data.data.next_redirect_pc_url);
+      });
   };
 
   const [point, setPoint] = useRecoilState(payState);

--- a/components/ui/ConfirmModal.tsx
+++ b/components/ui/ConfirmModal.tsx
@@ -2,29 +2,42 @@ import React from "react";
 import style from "@/components/ui/ConfirmModal.module.css";
 import Image from "next/image";
 import { useRouter } from "next/router";
+import axios from "@/configs/axiosConfig";
+import { useCookies } from "react-cookie";
 export default function ConfirmModal(props: {
   color: string;
-  situation: string;
+  situation: "부족" | "결제";
   epiId: number;
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const router = useRouter();
+  const [cookies] = useCookies(["uuid"]);
   let textInfo = "";
   let confirmInfoTitle = "";
   let imageSrc = "";
-  if (props.situation === "차감") {
-    textInfo = "100P 차감됐습니다.";
+  if (props.situation === "결제") {
+    textInfo = "100P를 사용하시겠습니까?";
     confirmInfoTitle = "읽기";
     imageSrc = "/assets/images/icons/bookwhite.svg";
   }
   if (props.situation === "부족") {
-    textInfo = "포인트가 부족합니다~";
+    textInfo = "포인트가 부족합니다.";
     confirmInfoTitle = "충전하기";
     imageSrc = "/assets/images/icons/plus.svg";
   }
-
+  const paymentHandle = async () => {
+    const res = await axios.post(`/payments-service/v1/payments/purchase`, {
+      uuid: cookies.uuid,
+      episodeId: props.epiId,
+    });
+    const data = JSON.parse(res.data.replace("data:", ""));
+    const userPoint = Number(localStorage.getItem("point"));
+    const afterPoint = userPoint - 100;
+    localStorage.setItem("point", afterPoint.toString());
+  };
   const movePage = () => {
-    if (props.situation === "차감") {
+    if (props.situation === "결제") {
+      paymentHandle();
       router.push(`/viewer/${props.epiId}`);
     }
     //부족

--- a/pages/kakao.tsx
+++ b/pages/kakao.tsx
@@ -24,6 +24,7 @@ export default function Kakao() {
         )
         .then((res) => {
           //localStorage.setItem("uuid", res.headers.uuid);
+          localStorage.setItem("name", res.data.data.name);
           localStorage.setItem("nickname", res.data.data.nickname);
           localStorage.setItem("point", res.data.data.point);
           localStorage.setItem("profileImg", res.data.data.profileImg);

--- a/pages/order-history.tsx
+++ b/pages/order-history.tsx
@@ -42,6 +42,7 @@ export default function OrderHistory() {
             point: data.body.data.point,
             chargeDate: data.body.data.chargeDate,
           });
+          localStorage.setItem("point", data.body.data.total);
         });
     }
   }, [pg_token]);


### PR DESCRIPTION
- 예전 결제 프로세스 : 유저가 에피소드 클릭 시 바로 포인트 차감과 동시에 차감 알림 후 읽기 버튼으로 감상
- -> 수정한 프로세스 : 유저가 에피소드 클릭 시 구매하는 게 맞는 지 알림 후 읽기 버튼을 누르면 포인트를 차감 후 감상
- 다른 곳에서 로그인 확인을 하기 때문에 불필요한 로그인 체크 코드를 삭제함.